### PR TITLE
Fixed the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ gglz <- ggLocusZoom(# Specify where the summary stats file is.
 ## Who?  
 
 *Brian M. Schilder*  
-[*__Raj Lab__*](www.rajlab.org)  
+[*__Raj Lab__*](https://www.rajlab.org)  
 *Department of Neuroscience*  
 *Department of Genetics & Genomic Sciences*    
 *Ronald M. Loeb Center for Alzheimer's Disease*  


### PR DESCRIPTION
Hi, 

I saw that a link does not redirect to the right website, due to how GitHub handles this (i.e. without the `https://` part, the link does not redirect to a proper website).

Hope you enjoy such a simple Pull Request :-)

Cheers, Richel Bilderbeek